### PR TITLE
Simplify URLs

### DIFF
--- a/resolve.macro.js
+++ b/resolve.macro.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const { createMacro } = require('babel-macros');
 const types = require('babel-types');
 const { commaLists, commaListsOr } = require('common-tags');
+const { getPartsFromTemplate } = require('./src/utils');
 
 function pathInvariant(path, predicate, message) {
   if (!predicate) {
@@ -100,7 +101,10 @@ function getQuasiFromString(string) {
 
 function processConfig(config) {
   config.forEach(info => {
-    info.quasis = info.strings.map(getQuasiFromString);
+    const { strings, params } = getPartsFromTemplate(info.template);
+    info.params = params;
+    info.quasis = strings.map(getQuasiFromString);
+    info.strings = strings;
   });
   return new Map(config.map(info => [info.name, info]));
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,9 @@
+function getPartsFromTemplate(template) {
+  const partRegex = /\$\{(\w+)\}/g;
+  const parts = template.split(partRegex);
+  const strings = parts.filter((element, index) => index % 2 === 0);
+  const params = parts.filter((element, index) => index % 2 === 1);
+  return { strings, params };
+}
+
+module.exports.getPartsFromTemplate = getPartsFromTemplate;

--- a/test/urls.js
+++ b/test/urls.js
@@ -4,17 +4,9 @@ module.exports = [
   {
     name: 'no-params',
     template: 'params/zero',
-    strings: ['params/zero'],
-    params: [],
   },
   {
     name: 'three-params',
     template: 'params/${first}-${second}/${third}/',
-    strings: ['params/', '-', '/', '/'],
-    params: [
-      'first',
-      'second',
-      'third',
-    ],
   },
 ];

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,62 @@
+function getPartsFromTemplate(template) {
+  const partRegex = /\$\{(\w+)\}/g;
+  const parts = template.split(partRegex);
+  const strings = parts.filter((element, index) => index % 2 === 0);
+  const params = parts.filter((element, index) => index % 2 === 1);
+  return { strings, params };
+}
+
+describe("getPartsFromTemplate", () => {
+  it("should work without params", () => {
+    expect(getPartsFromTemplate("no-params/zero")).toEqual({
+      strings: ["no-params/zero"],
+      params: []
+    });
+  });
+
+  it("should recognise params", () => {
+    expect(getPartsFromTemplate("params/${first}-${second}/${third}/")).toEqual(
+      {
+        strings: ["params/", "-", "/", "/"],
+        params: ["first", "second", "third"]
+      }
+    );
+  });
+
+  it("should not throw on extra symbols", () => {
+    expect(
+      getPartsFromTemplate("p$ar{}ams/${first}-${second}/${third}/")
+    ).toEqual({
+      strings: ["p$ar{}ams/", "-", "/", "/"],
+      params: ["first", "second", "third"]
+    });
+  });
+
+  it("should allow starting with a param", () => {
+    expect(getPartsFromTemplate("${foo}/bar")).toEqual({
+      strings: ["", "/bar"],
+      params: ["foo"]
+    });
+  });
+
+  it("should allow ending with a param", () => {
+    expect(getPartsFromTemplate("foo/${bar}")).toEqual({
+      strings: ["foo/", ""],
+      params: ["bar"]
+    });
+  });
+
+  it("should work with empty string", () => {
+    expect(getPartsFromTemplate("")).toEqual({
+      strings: [""],
+      params: []
+    });
+  });
+
+  it("should do nothing special if a param is not closed", () => {
+    expect(getPartsFromTemplate("${foo/bar")).toEqual({
+      strings: ["${foo/bar"],
+      params: []
+    });
+  });
+});

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,10 +1,4 @@
-function getPartsFromTemplate(template) {
-  const partRegex = /\$\{(\w+)\}/g;
-  const parts = template.split(partRegex);
-  const strings = parts.filter((element, index) => index % 2 === 0);
-  const params = parts.filter((element, index) => index % 2 === 1);
-  return { strings, params };
-}
+const { getPartsFromTemplate } = require('../src/utils');
 
 describe("getPartsFromTemplate", () => {
   it("should work without params", () => {


### PR DESCRIPTION
Only require `name` and `template` - the other fields should be calculated from it.